### PR TITLE
Limit number of publications and projects shown on author pages

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,3 +1,6 @@
 # Extras
 - id: Awards
   translation: Awards
+
+- id: see-previous
+  translation: See previous

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -4,3 +4,6 @@
 
 - id: see-previous
   translation: See previous
+
+- id: current-projects
+  translation: Current projects

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -4,3 +4,6 @@
 
 - id: see-previous
   translation: Ver anteriores
+
+- id: current-projects
+  translation: Proyectos actuales

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -1,3 +1,6 @@
 # Extras
 - id: Awards
   translation: Premios
+
+- id: see-previous
+  translation: Ver anteriores

--- a/layouts/partials/widgets/my_custom_about.html
+++ b/layouts/partials/widgets/my_custom_about.html
@@ -153,7 +153,6 @@
 {{ end }}
 
 {{/* Range Projects */}}
-{{ $show_first := 3 }}
 {{ $query := where site.RegularPages "Type" "projects" }}
 
 {{/* Filters */}}
@@ -163,17 +162,39 @@
 {{/* Sort */}}
 {{ $query = sort $query "Date" "desc" }}
 
-{{ with $query }}
-<div class="section-subheading">{{ i18n "projects" | markdownify }}</div>{{ range first $show_first $query }}
-{{ partial "li_list" . }}
-{{ end }}
-{{ if gt (len $query) $show_first}}
-<details>
-  <summary> {{ i18n "see-previous" }}  </summary>
-  <br>
-  {{ range after $show_first $query }}
-  {{ partial "li_list" . }}
+<!-- Empty arrays -->
+{{ $current_projects := slice }}
+{{ $past_projects := slice }}
+
+<!-- Separate $query in current or past, according to date_end -->
+<!-- If date_end is not defined, then date_end = date -->
+{{ $date_end := .Now.Unix }}
+{{ range $page := $query }}
+  {{ if isset $page.Params "date_end" }}
+    {{ $date_end = time $page.Params.date_end }}
+  {{ else }}
+    {{ $date_end = $page.Date }}
   {{ end }}
-</details>
+  {{ if gt $date_end.Unix now.Unix  }}
+    {{ $current_projects = $current_projects | append $page }}
+  {{ else }}
+    {{ $past_projects = $past_projects | append $page }}
+  {{ end }}
 {{ end }}
+
+{{ with $query }}
+
+<div class="section-subheading">{{ i18n "current-projects" | markdownify }}</div>
+{{ range $current_projects }}
+  {{ partial "li_list" . }}
+{{ end }}
+{{ with $past_projects }}
+  <details>
+    <summary> {{ i18n "see-previous" }}  </summary>
+    <br>
+    {{ range $past_projects }}
+    {{ partial "li_list" . }}
+    {{ end }}
+  </details>
+  {{ end }}
 {{ end }}

--- a/layouts/partials/widgets/my_custom_about.html
+++ b/layouts/partials/widgets/my_custom_about.html
@@ -128,6 +128,7 @@
 </div>
 
 {{/* Range publications */}}
+{{ $show_first := 3 }}
 {{ $query := where site.RegularPages "Type" "publications" }}
 
 {{/* Filters */}}
@@ -139,12 +140,20 @@
 
 {{ with $query }}
 <div class="section-subheading">{{ i18n "publications" | markdownify }}</div>
-{{ range $post := . }}
-{{ partial "li_citation" $post }}
+{{ range first $show_first $query }}
+{{ partial "li_citation" . }}
 {{ end }}
+<details>
+  <summary> {{ i18n "see-previous" }}  </summary>
+  <br>
+  {{ range after $show_first $query }}
+  {{ partial "li_citation" . }}
+  {{ end }}
+</details>
 {{ end }}
 
 {{/* Range Projects */}}
+{{ $show_first := 3 }}
 {{ $query := where site.RegularPages "Type" "projects" }}
 
 {{/* Filters */}}
@@ -155,8 +164,16 @@
 {{ $query = sort $query "Date" "desc" }}
 
 {{ with $query }}
-<div class="section-subheading">{{ i18n "projects" | markdownify }}</div>
-{{ range $post := . }}
-{{ partial "li_list" $post }}
+<div class="section-subheading">{{ i18n "projects" | markdownify }}</div>{{ range first $show_first $query }}
+{{ partial "li_list" . }}
+{{ end }}
+{{ if gt (len $query) $show_first}}
+<details>
+  <summary> {{ i18n "see-previous" }}  </summary>
+  <br>
+  {{ range after $show_first $query }}
+  {{ partial "li_list" . }}
+  {{ end }}
+</details>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
This PR solves issue #9. Collapsible sections were added for the publications and projects shown on the author pages. By default, the items shown are the last 3 publications as well as the current projects.

A project is selected as 'current' based on the variable `date_end` defined on its frontmatter. If `date_end` is posterior to the build date of the page, then the project is selected as current. Also, if `date_end` is not defined, it takes the same value as `date`.