### PR TITLE
Add section others to custom about widget

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -10,3 +10,6 @@
 
 - id: associated-publications
   translation: Associated publications
+
+- id: Others
+  translation: Others

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -10,3 +10,6 @@
 
 - id: associated-publications
   translation: Publicaciones asociadas
+
+- id: Others
+  translation: Otros

--- a/layouts/partials/widgets/my_custom_about.html
+++ b/layouts/partials/widgets/my_custom_about.html
@@ -123,6 +123,23 @@
       </div>
       {{ end }}
 
+      {{ with $person.others }}
+      <div class="col-md-7">
+        <div class="section-subheading">{{ i18n "Others" | markdownify }}</div>
+        <ul class="ul-edu fa-ul">
+          {{ range . }}
+          <li>
+            <i class="fa-li fas fa-sun"></i>
+            <div class="description">
+              <p class="course">{{ .description }}{{ with .year }}, {{ . }}{{ end }}</p>
+              <p class="institution">{{ .institution }}</p>
+            </div>
+          </li>
+          {{ end }}
+        </ul>
+      </div>
+      {{ end }}
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds a section 'Others' into personal pages, with possible subitems 'description', 'year', and 'institution'.