### PR TITLE
'about' widget in author pages: Delete section 'Awards' in favor of 'Others'

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,7 +1,4 @@
 # Extras
-- id: Awards
-  translation: Awards
-
 - id: see-previous
   translation: See previous
 

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -1,7 +1,4 @@
 # Extras
-- id: Awards
-  translation: Premios
-
 - id: see-previous
   translation: Ver anteriores
 

--- a/layouts/partials/widgets/my_custom_about.html
+++ b/layouts/partials/widgets/my_custom_about.html
@@ -112,7 +112,11 @@
         <ul class="ul-edu fa-ul">
           {{ range . }}
           <li>
-            <i class="fa-li fas fa-sun"></i>
+            {{/* Default icon */}}
+            {{ $icon := "sun" }}
+            {{/* Select icon from 'fa_icon' key */}}
+            {{ with .fa_icon }}{{ $icon = . }}{{ end }}
+            <i class="fa-li fas fa-{{ $icon }} "></i>
             <div class="description">
               <p class="course">{{ .description }}{{ with .year }}, {{ . }}{{ end }}</p>
               <p class="institution">{{ .institution }}</p>

--- a/layouts/partials/widgets/my_custom_about.html
+++ b/layouts/partials/widgets/my_custom_about.html
@@ -106,23 +106,6 @@
       </div>
       {{ end }}
 
-      {{ with $person.awards }}
-      <div class="col-md-7">
-        <div class="section-subheading">{{ i18n "Awards" | markdownify }}</div>
-        <ul class="ul-edu fa-ul">
-          {{ range . }}
-          <li>
-            <i class="fa-li fas fa-award"></i>
-            <div class="description">
-              <p class="course">{{ .award }}{{ with .year }}, {{ . }}{{ end }}</p>
-              <p class="institution">{{ .institution }}</p>
-            </div>
-          </li>
-          {{ end }}
-        </ul>
-      </div>
-      {{ end }}
-
       {{ with $person.others }}
       <div class="col-md-7">
         <div class="section-subheading">{{ i18n "Others" | markdownify }}</div>


### PR DESCRIPTION
To keep the page clean, the section 'Awards' is deleted in favor of the section 'Others'.

An optional key `fa_icon` is included for each element of 'Others' to allow choosing a different icon from the default ("fa-sun"). This key allows the use of an icon from the [fa icon-pack](https://fontawesome.com/icons), where the prefix 'fa-' must be dropped.