### PR TITLE
make 'url' key optional in section $person.others

### DIFF
--- a/layouts/partials/widgets/my_custom_about.html
+++ b/layouts/partials/widgets/my_custom_about.html
@@ -120,8 +120,8 @@
             <div class="description">
               <p class="course">{{ .description }}{{ with .year }}, {{ . }}{{ end }}</p>
               <p class="institution">{{ .institution }}</p>
-	      <p class="institution">{{ .date }}</p>
-	      <p class="institution"><a href="{{ .url }}"> {{ .url }} </p>
+              <p class="institution">{{ .date }}</p>
+              {{ with .url }}<p class="institution"><a href="{{ . }}"> {{ . }} </p>{{ end }}
             </div>
           </li>
           {{ end }}


### PR DESCRIPTION
Within an authors 'others' section it was assumed that a key 'url' was to be provided, inserting undesired (relative) empty links in the section when the key was missing. 

To solve it, I wrapped the url paragraph in a {{ with .url }} block, which only inserts the paragraph when the corresponding key (url) is provided in the current context (which is represented with a dot ".").